### PR TITLE
Wire shared Incutec KiCad library (submodule)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "libs/KiCad-Library"]
+	path = libs/KiCad-Library
+	url = https://github.com/incutec-hw/KiCad-Library.git

--- a/OpenRX-Gemini/fp-lib-table
+++ b/OpenRX-Gemini/fp-lib-table
@@ -1,3 +1,4 @@
 (fp_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
+	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/footprint/Incutec.pretty")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Gemini/sym-lib-table
+++ b/OpenRX-Gemini/sym-lib-table
@@ -1,3 +1,4 @@
 (sym_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
+	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/symbol/Incutec.kicad_sym")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Lite-UFL/fp-lib-table
+++ b/OpenRX-Lite-UFL/fp-lib-table
@@ -1,3 +1,4 @@
 (fp_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
+	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/footprint/Incutec.pretty")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Lite-UFL/sym-lib-table
+++ b/OpenRX-Lite-UFL/sym-lib-table
@@ -1,3 +1,4 @@
 (sym_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
+	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/symbol/Incutec.kicad_sym")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Lite/fp-lib-table
+++ b/OpenRX-Lite/fp-lib-table
@@ -1,3 +1,4 @@
 (fp_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
+	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/footprint/Incutec.pretty")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Lite/sym-lib-table
+++ b/OpenRX-Lite/sym-lib-table
@@ -1,3 +1,4 @@
 (sym_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
+	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/symbol/Incutec.kicad_sym")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Mono/fp-lib-table
+++ b/OpenRX-Mono/fp-lib-table
@@ -1,3 +1,4 @@
 (fp_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
+	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/footprint/Incutec.pretty")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Mono/sym-lib-table
+++ b/OpenRX-Mono/sym-lib-table
@@ -1,3 +1,4 @@
 (sym_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
+	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/symbol/Incutec.kicad_sym")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )


### PR DESCRIPTION
Wires the shared KiCad library into this repo:

- incutec-hw/KiCad-Library added as a submodule at libs/KiCad-Library, pinned to the feat/complete-library build (KiCad-Library#1)
- Project sym-lib-table / fp-lib-table gain the Incutec entries via ${KIPRJMOD} relative paths
- Existing local libraries untouched: they stay as the frozen record for already-routed boards

Verified: all table URIs resolve, all 195 footprints load through pcbnew from the submodule path, 105 symbols parse via kicad-cli. Clone with --recursive from now on.

After KiCad-Library#1 merges, re-pin with tools/bump-all.sh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)