### PR TITLE
Fix verification findings: style, slugs, depersonalization

### DIFF
--- a/archive/legacy-projects/OpenRX-900/fp-lib-table
+++ b/archive/legacy-projects/OpenRX-900/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
+  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../../../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
 )

--- a/archive/legacy-projects/OpenRX-900/sym-lib-table
+++ b/archive/legacy-projects/OpenRX-900/sym-lib-table
@@ -1,3 +1,3 @@
 (sym_lib_table
-  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
+  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../../../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
 )

--- a/archive/legacy-projects/OpenRX-Nano/fp-lib-table
+++ b/archive/legacy-projects/OpenRX-Nano/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
+  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../../../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
 )

--- a/archive/legacy-projects/OpenRX-Nano/sym-lib-table
+++ b/archive/legacy-projects/OpenRX-Nano/sym-lib-table
@@ -1,3 +1,3 @@
 (sym_lib_table
-  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
+  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../../../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
 )

--- a/archive/legacy-projects/OpenRX-PWM/fp-lib-table
+++ b/archive/legacy-projects/OpenRX-PWM/fp-lib-table
@@ -1,3 +1,3 @@
 (fp_lib_table
-  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
+  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../../../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
 )

--- a/archive/legacy-projects/OpenRX-PWM/sym-lib-table
+++ b/archive/legacy-projects/OpenRX-PWM/sym-lib-table
@@ -1,3 +1,3 @@
 (sym_lib_table
-  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
+  (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../../../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
 )


### PR DESCRIPTION
Fixes the remaining clean-room verification finding for this repo.

## Changes
- Corrected relative library URIs in the six archived legacy lib tables (`archive/legacy-projects/{OpenRX-900,OpenRX-Nano,OpenRX-PWM}/{sym,fp}-lib-table`). The projects were moved into `archive/legacy-projects/` without updating `${KIPRJMOD}/../shared/libs/`, which pointed at a nonexistent `archive/legacy-projects/shared/libs/`. Now `${KIPRJMOD}/../../../shared/libs/`, verified to resolve to the real `shared/libs/` in a clean clone.

## Already resolved on main (no change needed)
- FLASHING.md credential leak: fixed by PR #10.
- Em/en dashes in `verification/bom/add_lcsc_to_passives.py` and `verification/scripts/check_gpio_continuity.py`: no longer present on main.
- `OpenRX-Mono.kicad_pcb` DOC_TAGLINE em dash: no longer present on main; `.kicad_*` content is out of scope for this pass regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)