### PR TITLE
docs: GitHub links and Discord-first contributing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ replicate_layout.log
 
 # Production output (generated, re-exportable)
 **/production/
+**/production-*/
 
 # Vendor datasheet cache (local only, not distributed)
 datasheets/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libs/KiCad-Library"]
 	path = libs/KiCad-Library
-	url = https://github.com/incutec-hw/KiCad-Library.git
+	url = https://github.com/OpenDrone-hw/KiCad-Library.git

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,17 @@
 # Contributing
 
+## Talk to us first
+
+Before you open an issue, start a project, or write any code or CAD, bring the
+idea to the Discord server and tag the developers:
+
+https://discord.gg/v3sWmTcx3R
+
+Say what you want to change and why. Someone may already be working on it, the
+board may be held by another contributor, or the change may clash with a
+production run that is already committed. A short conversation there saves a
+pull request that cannot be merged.
+
 ## Before you edit a board
 
 KiCad files cannot be merged. If two people edit the same `.kicad_pcb`, one of

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ A pull request touching a file locked by someone else gets closed, not merged.
 ## Setup
 
 ```
-git clone --recursive https://github.com/incutec-hw/OpenRX.git
+git clone --recursive https://github.com/OpenDrone-hw/OpenRX.git
 ```
 
 KiCad 10. The `--recursive` flag pulls `libs/KiCad-Library`, which the project
@@ -41,7 +41,7 @@ kicad-cli pcb drc --exit-code-violations OpenRX-<variant>/OpenRX-<variant>.kicad
 Add new symbols, footprints and 3D models to this repo's local libraries.
 That is the working default.
 
-[incutec-hw/KiCad-Library](https://github.com/incutec-hw/KiCad-Library) is a
+[OpenDrone-hw/KiCad-Library](https://github.com/OpenDrone-hw/KiCad-Library) is a
 mirror of parts we already use or stock. Check it first: if the part is there,
 we have used it before, which saves sourcing work. Promoting a part into it is
 a separate deliberate step, not a requirement for contributing here.

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Clone with `--recursive` so the `libs/KiCad-Library` submodule is present. Libra
 ## Build and export
 
 ```
-git clone --recursive https://github.com/incutec-hw/OpenRX.git
+git clone --recursive https://github.com/OpenDrone-hw/OpenRX.git
 ```
 
 Open a variant's `.kicad_pro` in KiCad 10. Production exports (gerbers, BOM, CPL) are generated with the [KiCad Fabrication Toolkit](https://github.com/bennymeg/Fabrication-Toolkit) plugin, using the tracked per-variant `fabrication-toolkit-options.json`. Headless checks and exports use `kicad-cli`:


### PR DESCRIPTION
Documentation only, no design files touched, rebased onto the current main so it applies cleanly.

Two commits carried over from the older stacked branches:
- point every GitHub link at OpenDrone-hw (README, CONTRIBUTING, .gitmodules)
- CONTRIBUTING.md now opens with a "Talk to us first" section pointing at the Discord server

Supersedes #19, #20 and #22. Those three were stacked on each other and #22 conflicted with main on OpenRX-Gemini.kicad_pcb and OpenRX-Mono.kicad_pcb over a 3D model choice, which is a separate decision from the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)