### PR TITLE
README: standardised link row, specs from the shop, status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,55 +11,44 @@ firmware, and differ in radio, band, RF front end and antenna.
 <img src="images/openrx-gemini-front.png" width="200" alt="OpenRX-Gemini" />
 </p>
 
-| Variant | Radio | Band | Antenna |
-|---|---|---|---|
-| **Lite** | SX1281 | 2.4 GHz | Chip antenna |
-| **Lite-UFL** | SX1281 | 2.4 GHz | U.FL |
-| **Mono** | LR1121 | Dual band | U.FL |
-| **Gemini** | 2x LR1121 | Dual band, Xrossband | 2x U.FL |
+[![Status](https://img.shields.io/badge/status-alpha-e08c00)](https://github.com/OpenDrone-hw/.github/blob/main/CONTRIBUTING.md#the-life-of-a-project)
+[![Shop](https://img.shields.io/badge/shop-opendrone.be-c89d2e)](https://opendrone.be/products/openrx)
+[![Discord](https://img.shields.io/badge/Discord-%23receivers-5865F2?logo=discord&logoColor=white)](https://discord.com/channels/1494019459822653512/1494758332903456969)
+[![Video](https://img.shields.io/badge/YouTube-How%20ExpressLRS%20Receivers%20Work-FF0000?logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=ssmQkRkXE84)
 
-All four are 6-layer boards, 5 V input, CRSF over UART.
+## Specifications
 
-<a href="https://certification.oshwa.org/list.html">
-  <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="images/oshwa-certified-dark.svg" />
-    <img src="images/oshwa-certified.svg" width="160" alt="OSHWA Certified Open Source Hardware" />
-  </picture>
-</a>
+| | Lite | Lite-UFL | Mono | Gemini |
+|---|---|---|---|---|
+| Band | 2.4 GHz | 2.4 GHz | Dual band | Dual band, Xrossband |
+| Radio | SX1281 | SX1281 | LR1121 | 2x LR1121 |
+| Antenna | On-board ceramic | U.FL | U.FL | 2x U.FL |
+| Telemetry power | 13 dBm (20 mW) | 13 dBm (20 mW) | | |
+| Protocol | CRSF | CRSF | CRSF | CRSF |
+| MCU | ESP32-C3 | ESP32-C3 | ESP32-C3 | ESP32-C3 |
+| Input | 5 V pad | 5 V pad | 5 V pad | 5 V pad |
+| Firmware | ExpressLRS | ExpressLRS | ExpressLRS | ExpressLRS |
+| Flashing | Betaflight passthrough or Wi-Fi | Betaflight passthrough or Wi-Fi | Betaflight passthrough or Wi-Fi | Betaflight passthrough or Wi-Fi |
+| Wi-Fi antenna | Separate on-board ceramic | Separate on-board ceramic | Separate on-board ceramic | Separate on-board ceramic |
+| Dimensions | 10.0 x 11.5 mm | 10.0 x 11.5 mm | | |
+| PCB | 6-layer, 1.6 mm | 6-layer, 1.6 mm | 6-layer | 6-layer |
 
-Certified open source hardware by the [Open Source Hardware Association](https://www.oshwa.org/),
-one UID per variant:
+OSHWA certified, one UID per variant:
 [Lite BE000030](https://certification.oshwa.org/be000030.html) ·
 [Lite-UFL BE000031](https://certification.oshwa.org/be000031.html) ·
 [Mono BE000032](https://certification.oshwa.org/be000032.html) ·
 [Gemini BE000033](https://certification.oshwa.org/be000033.html)
 
+Technical write-up, part list and layout constraints: [AGENTS.md](AGENTS.md).
+
 ## In the line
 
-Pairs with any OpenDrone flight controller over the 4-pin receiver connector:
-
-- [OpenFC-Lite](https://github.com/OpenDrone-hw/OpenFC-Lite), 30.5 x 30.5 mm
-- [OpenFC-Lite-Mini](https://github.com/OpenDrone-hw/OpenFC-Lite-Mini), 20 x 20 mm
-
-Firmware is [ExpressLRS](https://github.com/ExpressLRS/ExpressLRS) upstream, not
-a fork. Targets are declared in `shared/elrs-targets/`.
-
-## Get one
-
-[opendrone.be](https://opendrone.be)
-
-Build video: [How LoRa (ExpressLRS) Drone Receivers Work](https://www.youtube.com/watch?v=ssmQkRkXE84)
-on [JustFPV](https://www.youtube.com/@justfpv1432)
+What pairs with what, and what is available:
+[opendrone.be](https://opendrone.be).
 
 ## Contributing
 
-Issues and pull requests are welcome on any repo. KiCad files cannot be merged,
-so say what you intend to change before you do, on
-[Discord](https://discord.gg/v3sWmTcx3R).
-
-The design itself, the part list and the layout constraints are in
-[AGENTS.md](AGENTS.md). How everything works:
-[CONTRIBUTING.md](CONTRIBUTING.md).
+See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## License
 


### PR DESCRIPTION
Same README shape across all five alpha repos.

- **Status** is a badge linking to the stage ladder in the org CONTRIBUTING, rather than described here.
- **Outbound links** move out of prose into one standardised row: status, shop, the product's Discord channel, its build video, OSHWA where certified.
- **Specifications** synced from the product page on opendrone.be, which is the maintained copy for now.
- **"In the line"** points at opendrone.be rather than listing siblings by hand.
- Removed: the JustFPV teardown line (now the video badge) and, on OpenESC-30x30, the bundled 3D model licence note.
- README points at `AGENTS.md` for the technical write-up and `CONTRIBUTING.md` for contributing.

All six outbound URLs verified 200.

### Four spec conflicts, website vs design files

Copied the website value and did **not** change the design files. These need your call, because in two cases the site looks wrong:

| Repo | Website | Design files |
|---|---|---|
| OpenESC-20x20 | Input **2-6S** | `DESIGN.md`: "The board is 6S only" |
| OpenESC-20x20 | PCB **1.6 mm** | 1.69 mm |
| OpenFC-Lite-Mini | **3** UARTs | 4: two hardware, two PIO |
| OpenFC-Lite-Mini | OSD **analog and digital** | Analog only, no digital VTX port |

### And one that I did not copy

The shop's OpenRX table lists **Lite-UFL antenna as "On-board ceramic"**, identical to Lite. The design files say Lite-UFL terminates at a **U.FL connector**, which is the entire point of the variant. I used U.FL. The shop page needs fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)