### PR TITLE
Drop the KiCad-Library submodule: nothing references it

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "libs/KiCad-Library"]
-	path = libs/KiCad-Library
-	url = https://github.com/OpenDrone-hw/KiCad-Library.git

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ radio IC, frequency band, RF front end and antenna interface. All four are
 | Layout | Multi-variant. One directory per variant at repo root, each with its own KiCad project |
 | Variants | `OpenRX-Lite/`, `OpenRX-Lite-UFL/`, `OpenRX-Mono/`, `OpenRX-Gemini/` |
 | Shared | `shared/sheets/` hierarchical sheets, `shared/libs/`, `shared/elrs-targets/` firmware target JSON |
-| Shared library | [OpenDrone-hw/KiCad-Library](https://github.com/OpenDrone-hw/KiCad-Library), submodule at `libs/KiCad-Library` |
+| Shared library | [OpenDrone-hw/KiCad-Library](https://github.com/OpenDrone-hw/KiCad-Library), catalogue only; every library this board uses is local to the repo |
 | Archive | `archive/legacy-projects/` holds five superseded designs. Historical record, not maintained |
 | License | CERN-OHL-S-2.0 |
 
@@ -118,7 +118,7 @@ Minimum ExpressLRS version **3.5.0**, as declared by `min_version` in `targets_e
 
 ## Libraries
 
-Symbols and footprints are embedded in the design files. The project lib tables reference the in-repo `shared/libs/OpenRX-Shared.*` library (`${KIPRJMOD}/../shared/libs/`) and the shared `Incutec` library from the `libs/KiCad-Library` git submodule (`${KIPRJMOD}/../libs/KiCad-Library/`). Passives and some packages (coax connectors, QFNs) use stock KiCad library footprints resolved through their embedded copies. Symbols carry an `LCSC` property for JLCPCB BOM export.
+Symbols and footprints are embedded in the design files. The project lib tables reference the in-repo `shared/libs/OpenRX-Shared.*` library (`${KIPRJMOD}/../shared/libs/`). Passives and some packages (coax connectors, QFNs) use stock KiCad library footprints resolved through their embedded copies. Symbols carry an `LCSC` property for JLCPCB BOM export.
 
 ## Revisions
 

--- a/OpenRX-Gemini/fp-lib-table
+++ b/OpenRX-Gemini/fp-lib-table
@@ -1,4 +1,3 @@
 (fp_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/footprint/Incutec.pretty")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Gemini/sym-lib-table
+++ b/OpenRX-Gemini/sym-lib-table
@@ -1,4 +1,3 @@
 (sym_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/symbol/Incutec.kicad_sym")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Lite-UFL/fp-lib-table
+++ b/OpenRX-Lite-UFL/fp-lib-table
@@ -1,4 +1,3 @@
 (fp_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/footprint/Incutec.pretty")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Lite-UFL/sym-lib-table
+++ b/OpenRX-Lite-UFL/sym-lib-table
@@ -1,4 +1,3 @@
 (sym_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/symbol/Incutec.kicad_sym")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Lite/fp-lib-table
+++ b/OpenRX-Lite/fp-lib-table
@@ -1,4 +1,3 @@
 (fp_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/footprint/Incutec.pretty")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Lite/sym-lib-table
+++ b/OpenRX-Lite/sym-lib-table
@@ -1,4 +1,3 @@
 (sym_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/symbol/Incutec.kicad_sym")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Mono/fp-lib-table
+++ b/OpenRX-Mono/fp-lib-table
@@ -1,4 +1,3 @@
 (fp_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.pretty")(options "")(descr "Shared footprints for all OpenRX receivers"))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/footprint/Incutec.pretty")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )

--- a/OpenRX-Mono/sym-lib-table
+++ b/OpenRX-Mono/sym-lib-table
@@ -1,4 +1,3 @@
 (sym_lib_table
   (lib (name "OpenRX-Shared")(type "KiCad")(uri "${KIPRJMOD}/../shared/libs/OpenRX-Shared.kicad_sym")(options "")(descr "Shared symbols for all OpenRX receivers"))
-	(lib (name "Incutec")(type "KiCad")(uri "${KIPRJMOD}/../libs/KiCad-Library/symbol/Incutec.kicad_sym")(options "")(descr "incutec shared library (submodule libs/KiCad-Library)"))
 )


### PR DESCRIPTION
Verified across the design files: zero `Incutec:` symbols or footprints placed, zero 3D paths into `libs/KiCad-Library`. Boards are fully self-contained by the copy-local policy, so the submodule only cost recursive clones and pin maintenance. KiCad-Library remains the catalogue of manufactured parts, referenced by docs, not by designs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)