### PR TITLE
Lite-UFL J1: LCSC C88374 on board and schematic

### DIFF
--- a/OpenRX-Lite-UFL/OpenRX-Lite-UFL.kicad_pcb
+++ b/OpenRX-Lite-UFL/OpenRX-Lite-UFL.kicad_pcb
@@ -4219,6 +4219,19 @@
 				)
 			)
 		)
+		(property "LCSC" "C88374"
+			(at 0 0 0)
+			(unlocked yes)
+			(layer "F.Fab")
+			(hide yes)
+			(uuid "d1c86c7c-7cf7-4ae5-8c49-8e5d6a62a190")
+			(effects
+				(font
+					(size 1 1)
+					(thickness 0.15)
+				)
+			)
+		)
 		(property ki_fp_filters "*BNC* *SMA* *SMB* *SMC* *Cinch* *LEMO* *UMRF* *MCX* *U.FL*")
 		(path "/d4225140-81df-42e7-abd7-e679e5ab5187/8389217b-a456-4d8a-943b-1370b0cf62e0")
 		(sheetname "/ESP32-C3 + SX1281 Core (UFL)/")

--- a/OpenRX-Lite-UFL/esp32c3_sx1281_lite.kicad_sch
+++ b/OpenRX-Lite-UFL/esp32c3_sx1281_lite.kicad_sch
@@ -9484,7 +9484,7 @@
 				)
 			)
 		)
-		(property "LCSC" " C88374"
+		(property "LCSC" "C88374"
 			(at 187.96 116.84 0)
 			(hide yes)
 			(show_name no)


### PR DESCRIPTION
First catch of the new step-3b checker: J1's LCSC was ' C88374' in the schematic (leading space) and absent from the board, so the toolkit BOM had no U.FL connector and JLC would never place it. Both fixed, metadata only, export re-verified: C1/C2/C3 clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)