### PR TITLE
OpenRX maintainer is @bastian2001

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ radio IC, frequency band, RF front end and antenna interface. All four are
 
 | | |
 |---|---|
-| Maintainer | @Just4Stan. Taken over from @bastian2001 on 2026-08-11 |
+| Maintainer | @bastian2001 |
 | Status | See the `status-*` topic on the repo. Never written here. |
 | Designed in | KiCad 10 |
 | Layout | Multi-variant. One directory per variant at repo root, each with its own KiCad project |


### PR DESCRIPTION
The header table read `@Just4Stan. Taken over from @bastian2001 on 2026-08-11`. Taking over ordering and the final release prep is not a change of maintainer: Bastian designed all four receivers and maintains them, so the table now names him alone.

Raised by Stan while fact-checking the product pages: the website's contributor wall was ranking by commit count, which put 153 docs and scaffolding commits ahead of the 8 that are the actual boards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)