### PR TITLE
README: status badge from the site endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ firmware, and differ in radio, band, RF front end and antenna.
 <img src="images/openrx-gemini-front.png" width="200" alt="OpenRX-Gemini" />
 </p>
 
-[![Status](https://img.shields.io/badge/status-alpha-e08c00)](https://github.com/OpenDrone-hw/.github/blob/main/CONTRIBUTING.md#the-life-of-a-project)
+[![Status](https://img.shields.io/endpoint?url=https://opendrone.be/api/status/OpenRX.json)](https://github.com/OpenDrone-hw/.github/blob/main/CONTRIBUTING.md#the-life-of-a-project)
 [![Shop](https://img.shields.io/badge/shop-opendrone.be-ffb700)](https://opendrone.be/products/openrx)
 [![Discord](https://img.shields.io/badge/Discord-%23receivers-5865F2?logo=discord&logoColor=white)](https://discord.com/channels/1494019459822653512/1494758332903456969)
 [![Video](https://img.shields.io/badge/YouTube-How%20ExpressLRS%20Receivers%20Work-FF0000?logo=youtube&logoColor=white)](https://www.youtube.com/watch?v=ssmQkRkXE84)


### PR DESCRIPTION
The status badge now renders from opendrone.be/api/status/OpenRX.json, the same status-* topic fetch the roadmap and shop resolve, so the README can never state a status the repo does not carry. Org-wide change; contract in the org CONTRIBUTING (OpenDrone-hw/.github#7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)